### PR TITLE
Limit target columns to one and sort classes

### DIFF
--- a/src/api/database.py
+++ b/src/api/database.py
@@ -93,7 +93,9 @@ class DatasetColumn(SQLModel, table=True):
         default=None, sa_column=Column(Enum(DatasetColumnTypeEnum))
     )
     unique_values: int = Field(default=0, nullable=False)
-    classes: List[str] = Field(default=[], nullable=False)
+    classes: Optional[List[str]] = Field(
+        default=None, sa_column=Column(JSON, nullable=True)
+    )
     null_count: int = Field(default=0, nullable=False)
     dataset_id: int = Field(
         default=None, foreign_key="dataset.id"

--- a/src/api/database.py
+++ b/src/api/database.py
@@ -93,6 +93,7 @@ class DatasetColumn(SQLModel, table=True):
         default=None, sa_column=Column(Enum(DatasetColumnTypeEnum))
     )
     unique_values: int = Field(default=0, nullable=False)
+    classes: List[str] = Field(default=[], nullable=False)
     null_count: int = Field(default=0, nullable=False)
     dataset_id: int = Field(
         default=None, foreign_key="dataset.id"

--- a/src/api/routers/datasets.py
+++ b/src/api/routers/datasets.py
@@ -34,6 +34,11 @@ async def upload_dataset(
     sniffer = csv.Sniffer()
     delimiter = sniffer.sniff(content).delimiter
     df = pd.read_csv(io.StringIO(content), delimiter=delimiter)
+    
+    classes = {}
+    for col in df.columns:
+        classes[col] = sorted(df[col].astype(str).unique().tolist())
+
     row_count = df.shape[0]
 
     dataset = Dataset(

--- a/src/api/routers/datasets.py
+++ b/src/api/routers/datasets.py
@@ -60,6 +60,7 @@ async def upload_dataset(
             name=col,
             type="categorical" if df[col].dtype == "object" else "numeric",
             unique_values=df[col].nunique(),
+            classes=classes[col],
             null_count=int(df[col].isnull().sum()),
             dataset_id=dataset.id,
         )

--- a/src/api/schemas/dataset.py
+++ b/src/api/schemas/dataset.py
@@ -19,6 +19,7 @@ class DatasetColumn(SQLModel, CamelModel):
     name: str
     type: DatasetColumnTypeEnum
     unique_values: int = 0
+    classes: list[str] | None = None
     null_count: int = 0
     dataset_id: int | None = None
 

--- a/src/trainer/datasets/data_preparation.py
+++ b/src/trainer/datasets/data_preparation.py
@@ -35,6 +35,9 @@ class DataPreparation:
         return self.df
     
     def select_input_columns(self, input_cols: list[int], target_cols: list[int] = []) -> None:
+        if len(target_cols) > 1:
+            raise ValueError("Only one target column is allowed for now")
+        
         total_columns = len(self.df.columns)
         all_indices = set(input_cols + target_cols)
 
@@ -65,7 +68,7 @@ class DataPreparation:
         self.target_cols = target_col_names
 
         for col in self.target_cols:
-            self.classes[col] = self.df[col].astype(str).unique().tolist()
+            self.classes[col] = sorted(self.df[col].astype(str).unique().tolist())
 
         self.df = pd.get_dummies(self.df, columns=self.target_cols, prefix="", prefix_sep="")
 


### PR DESCRIPTION
Restrict the selection of target columns to a maximum of one and ensure that unique class values for each column are sorted before being stored in the database.